### PR TITLE
feat(gradle): upgrade to gradle 8.1.0 and add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.amrahmd.native_locale' 
+
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
New versions of flutter requires upgrading gradle version for the app and it's dependencies.